### PR TITLE
Update Apache Pulsar to depend on JDK17, attempt ARM build

### DIFF
--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -22,6 +22,7 @@ class ApachePulsar < Formula
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf" => :build
+  depends_on arch: :x86_64
   depends_on "openjdk@17"
 
   def install

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -5,6 +5,7 @@ class ApachePulsar < Formula
   mirror "https://archive.apache.org/dist/pulsar/pulsar-2.10.0/apache-pulsar-2.10.0-src.tar.gz"
   sha256 "fadf27077c5a15852791bea45f34191de1edc25799ecd6e2730a9ff656789c0b"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/pulsar.git", branch: "master"
 
   bottle do
@@ -21,11 +22,10 @@ class ApachePulsar < Formula
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf" => :build
-  depends_on arch: :x86_64
-  depends_on "openjdk@11"
+  depends_on "openjdk@17"
 
   def install
-    with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("11")) do
+    with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("17")) do
       system "mvn", "-X", "clean", "package", "-DskipTests", "-Pcore-modules"
     end
 
@@ -47,7 +47,7 @@ class ApachePulsar < Formula
     libexec.glob("bin/*") do |path|
       if !path.fnmatch?("*common.sh") && !path.directory?
         bin_name = path.basename
-        (bin/bin_name).write_env_script libexec/"bin"/bin_name, Language::Java.java_home_env("11")
+        (bin/bin_name).write_env_script libexec/"bin"/bin_name, Language::Java.java_home_env("17")
       end
     end
   end

--- a/Formula/castget.rb
+++ b/Formula/castget.rb
@@ -11,13 +11,14 @@ class Castget < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_monterey: "dab2c9c9952ce1ecd3263ed1d6c1c002c772c9e7c310bde0b6277c46fd424edf"
-    sha256 cellar: :any, arm64_big_sur:  "320ee21622d1bd939ea95055395d84e5d7cb2d6f091d0da9f05c9eb3d0cff7b9"
-    sha256 cellar: :any, monterey:       "e504eb4b4d6c38f21fdb20a8424de8ac6e98ee4dd970c397da89c0f936520be6"
-    sha256 cellar: :any, big_sur:        "b91da84bac0b31dfb521f193b519c984cf943f15974f9427fa3e780028ea07aa"
-    sha256 cellar: :any, catalina:       "83d589037e4418829134060be140fce4b4b9883b9b68376f20257df68d9fff9a"
-    sha256 cellar: :any, mojave:         "fedc8c680b948b9f87cfd3f63f90bd6cb02143120a9c74d5b1bc5a04e84290d9"
-    sha256 cellar: :any, high_sierra:    "4d1f21bb31abc39d28110a76608493423f96a1f19c4b67c1cb651887f3848675"
+    sha256 cellar: :any,                 arm64_monterey: "dab2c9c9952ce1ecd3263ed1d6c1c002c772c9e7c310bde0b6277c46fd424edf"
+    sha256 cellar: :any,                 arm64_big_sur:  "320ee21622d1bd939ea95055395d84e5d7cb2d6f091d0da9f05c9eb3d0cff7b9"
+    sha256 cellar: :any,                 monterey:       "e504eb4b4d6c38f21fdb20a8424de8ac6e98ee4dd970c397da89c0f936520be6"
+    sha256 cellar: :any,                 big_sur:        "b91da84bac0b31dfb521f193b519c984cf943f15974f9427fa3e780028ea07aa"
+    sha256 cellar: :any,                 catalina:       "83d589037e4418829134060be140fce4b4b9883b9b68376f20257df68d9fff9a"
+    sha256 cellar: :any,                 mojave:         "fedc8c680b948b9f87cfd3f63f90bd6cb02143120a9c74d5b1bc5a04e84290d9"
+    sha256 cellar: :any,                 high_sierra:    "4d1f21bb31abc39d28110a76608493423f96a1f19c4b67c1cb651887f3848675"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "590a6ec3e2fe983ff5c82e3b5b96b43c87f3a51fd7848216da86dc48ba01b8ca"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/cppcheck.rb
+++ b/Formula/cppcheck.rb
@@ -1,8 +1,8 @@
 class Cppcheck < Formula
   desc "Static analysis of C and C++ code"
   homepage "https://sourceforge.net/projects/cppcheck/"
-  url "https://github.com/danmar/cppcheck/archive/2.7.5.tar.gz"
-  sha256 "6c7ac29e57fa8b3ac7be224510200e579d5a90217e2152591ef46ffc947d8f78"
+  url "https://github.com/danmar/cppcheck/archive/2.8.tar.gz"
+  sha256 "57298f3b805f0eb816a04115fbc70e701f75083cfb0305a44246e365cf27606a"
   license "GPL-3.0-or-later"
   head "https://github.com/danmar/cppcheck.git", branch: "main"
 

--- a/Formula/cppcheck.rb
+++ b/Formula/cppcheck.rb
@@ -7,12 +7,12 @@ class Cppcheck < Formula
   head "https://github.com/danmar/cppcheck.git", branch: "main"
 
   bottle do
-    sha256 arm64_monterey: "900e08329dda2382b00846dcbc78f4e690e1939a7e7c22bf7d3c7c609c763cbb"
-    sha256 arm64_big_sur:  "1756159b82e6743f9f94b307d9887bb955ff3cce98ed70df2a3acb132d9ef955"
-    sha256 monterey:       "e19bd6218630cfe85067e9bcb9d47fde1e5bcd088090f2407ac6f5b30dd05548"
-    sha256 big_sur:        "af962c41f017ddddf9d8d0d1080c8fb104067263af076f9e91427af918d02a87"
-    sha256 catalina:       "036ab97bc7a535f7345993056c1f3095586b508cb0e7528982e3285ad2f861ce"
-    sha256 x86_64_linux:   "7a94ab586adc08dd0db6af1588d5632287960ec26cb895d7bfb6e640e5a2be6a"
+    sha256 arm64_monterey: "74bc7a492faf75198814aaccde6772617cd0dcff3735ec1092790c29e3b9e1f6"
+    sha256 arm64_big_sur:  "02956de36ee59d032e13022722f8f69c0e2be0b20aed5e8b0d2e2ec647616942"
+    sha256 monterey:       "11bdd1a7ece5dfe1056735313716301ddf199eff7d994679c70e0e4fd2f33904"
+    sha256 big_sur:        "1287826c7ff64634eea737fdecf318aaae8a39b71e321d9bb31a08736b0b0457"
+    sha256 catalina:       "8bfe8af131aea999697fe7c853d17e02fa3ecfb9b52d65e41149a798ac46a854"
+    sha256 x86_64_linux:   "b77b3f59ea3d5f37a14b45db3b57249652b0c0f109e1474c79921ec21e808500"
   end
 
   depends_on "cmake" => :build

--- a/Formula/easy-tag.rb
+++ b/Formula/easy-tag.rb
@@ -7,9 +7,12 @@ class EasyTag < Formula
   revision 6
 
   bottle do
-    sha256 arm64_big_sur: "8a1cef2c91b3216179ce0eb8ace40e845c2956bb08602747d9c4b433b8c138e2"
-    sha256 big_sur:       "f10db53f7c6852dc2d83920c64b5166612b7ebfcfd8b8789228bcc2917b183c4"
-    sha256 catalina:      "cf12b241113c19be8fb1b91871d0428f29c9d4e39066c5fd0c197bba1f12088a"
+    sha256 arm64_monterey: "39d4f47a2a8310fbef48070f247e2ec45cc0761bf5e1baa8ebda5446e1aee0b4"
+    sha256 arm64_big_sur:  "8a1cef2c91b3216179ce0eb8ace40e845c2956bb08602747d9c4b433b8c138e2"
+    sha256 monterey:       "d0ef9d0bc6d61b5c2c68b1f26d363a1ed2fd95c5dbe671e6492e94db032d9b3d"
+    sha256 big_sur:        "f10db53f7c6852dc2d83920c64b5166612b7ebfcfd8b8789228bcc2917b183c4"
+    sha256 catalina:       "cf12b241113c19be8fb1b91871d0428f29c9d4e39066c5fd0c197bba1f12088a"
+    sha256 x86_64_linux:   "f33415cd657483d9eea16b2d51d12938cb2cc2296662c0761142ad760f5c21c4"
   end
 
   depends_on "intltool" => :build

--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -1,8 +1,8 @@
 class Fastlane < Formula
   desc "Easiest way to build and release mobile apps"
   homepage "https://fastlane.tools"
-  url "https://github.com/fastlane/fastlane/archive/2.206.0.tar.gz"
-  sha256 "ac88a531d778901109936b797546dbeb120737e3102d6572c315ccbee09d0e41"
+  url "https://github.com/fastlane/fastlane/archive/2.206.1.tar.gz"
+  sha256 "31cb2423a60d4f5e0001a5914aef82dfdd40963092ca3b66626c1fb3d5e70eda"
   license "MIT"
   head "https://github.com/fastlane/fastlane.git", branch: "master"
 

--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -12,12 +12,12 @@ class Fastlane < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "e22992524090738446d9b722734cd5f277b7ac7cb1e3377a42d0e405b943475a"
-    sha256 cellar: :any,                 arm64_big_sur:  "a447fd70a168249d19cd7536b6b30a7cfae1a96e8136c0a40b94ee62e493bd52"
-    sha256 cellar: :any,                 monterey:       "200680d5f2f8a9ffda4296811f9839ba6b454fd548068a99ee9f336349525674"
-    sha256 cellar: :any,                 big_sur:        "977ce0a04ec4565cad138d544f6eb8d7553dd4c05494d176a9a5fceab6144250"
-    sha256 cellar: :any,                 catalina:       "35c4ff9f265884d556c38a33920afcdfbd960a104e1c9b31dcab10136c084ea1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1cf80612418d89ed5df7e9e6ea7330dd5b8c93d2d7315d58bd01f73c96357cac"
+    sha256 cellar: :any,                 arm64_monterey: "5b54a28358d4f7ede81b1b83c9b34f42e898ffb348b9cb2f7ae9fd7e8f37b980"
+    sha256 cellar: :any,                 arm64_big_sur:  "6ce12df6e3bfb1a1d9935a9be3c59ad7918a742312aafdf8ddb94d8fbb83d3c0"
+    sha256 cellar: :any,                 monterey:       "426e58aa7efa7a008f58722bba49ab978b3d3ad79b31fb79f78ace76ef212207"
+    sha256 cellar: :any,                 big_sur:        "aa066037746bede21719ded0334feb75d8feb8d392c5cc5495bba496089d1658"
+    sha256 cellar: :any,                 catalina:       "3f931f98ec1ed8c82f85351efc3f6583153a1d604d5f66948abceb23e3225d1d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0ccaaccbeaa9eef762371f1d887eda3a0e15c06dfdc540c0f98aa8f1afc30248"
   end
 
   depends_on "ruby"

--- a/Formula/gwyddion.rb
+++ b/Formula/gwyddion.rb
@@ -11,9 +11,12 @@ class Gwyddion < Formula
   end
 
   bottle do
-    sha256 arm64_big_sur: "9a5ba5a71bd35ec492de7fe9840419ec8922daf04a31c9ebb58ba8bee59c9723"
-    sha256 big_sur:       "acfbd4430428e964b062cd8f5e43cf96fad56127801b57e07493f3550efe3eac"
-    sha256 catalina:      "ea3562016bd81e226579e0f92aa161d4551a870e46edb25dfae5bf38c0d0874b"
+    sha256 arm64_monterey: "af9865335f78231bee3ff95b2def880998fc437853112b03696a4d2c52c5580e"
+    sha256 arm64_big_sur:  "9a5ba5a71bd35ec492de7fe9840419ec8922daf04a31c9ebb58ba8bee59c9723"
+    sha256 monterey:       "d64d78a7b938e5147a787e9ea6276496f6e4b97fd7979534d715a04bc19ff79d"
+    sha256 big_sur:        "acfbd4430428e964b062cd8f5e43cf96fad56127801b57e07493f3550efe3eac"
+    sha256 catalina:       "ea3562016bd81e226579e0f92aa161d4551a870e46edb25dfae5bf38c0d0874b"
+    sha256 x86_64_linux:   "991d25f826d4903328f4c15bd88ad8a405aba45074408deaef8982a8c24cb41b"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/id3v2.rb
+++ b/Formula/id3v2.rb
@@ -6,16 +6,17 @@ class Id3v2 < Formula
   license "LGPL-2.1"
 
   bottle do
-    sha256 cellar: :any, arm64_monterey: "d987f37e40ed136bf3eb8a46e867dad0a78f48a1b5457085161f90404b1eee20"
-    sha256 cellar: :any, arm64_big_sur:  "4eb1279baa3350a16d82139446ab610aa897087821c2dd6fce2a12fac692f958"
-    sha256 cellar: :any, monterey:       "f2ef072277b52404b538228954a139a02828b20696ffe12b968d1ae64a40d70a"
-    sha256 cellar: :any, big_sur:        "363e3ccb0976eddc681538d70f43e498eafc6b03b31bcb1f3f4fccb2382790d9"
-    sha256 cellar: :any, catalina:       "2476bad339650dc2c12e3dd074b3aba7058e9b3b07c9caf05d6f068ea216d9ef"
-    sha256 cellar: :any, mojave:         "f0e2da49b513dce2ab73589b2aed98ae2cca184dbe082f92502d87e96ba9731d"
-    sha256 cellar: :any, high_sierra:    "ca2c1296318425931c5eec52c70adf98665edeb19d5b681271c3b6353ddf171a"
-    sha256 cellar: :any, sierra:         "3b1d75af49217a58f5ecb6f0e9e34564b299903898c76145218a6496de3a7778"
-    sha256 cellar: :any, el_capitan:     "941e267b5a214013c8085c7918c0d8c1805c906cacf162191b764d2ae1df265f"
-    sha256 cellar: :any, yosemite:       "cd8dd2f943081a051214bf0eedb3c1431abf2bb060a528058e6b9d4c841995ce"
+    sha256 cellar: :any,                 arm64_monterey: "d987f37e40ed136bf3eb8a46e867dad0a78f48a1b5457085161f90404b1eee20"
+    sha256 cellar: :any,                 arm64_big_sur:  "4eb1279baa3350a16d82139446ab610aa897087821c2dd6fce2a12fac692f958"
+    sha256 cellar: :any,                 monterey:       "f2ef072277b52404b538228954a139a02828b20696ffe12b968d1ae64a40d70a"
+    sha256 cellar: :any,                 big_sur:        "363e3ccb0976eddc681538d70f43e498eafc6b03b31bcb1f3f4fccb2382790d9"
+    sha256 cellar: :any,                 catalina:       "2476bad339650dc2c12e3dd074b3aba7058e9b3b07c9caf05d6f068ea216d9ef"
+    sha256 cellar: :any,                 mojave:         "f0e2da49b513dce2ab73589b2aed98ae2cca184dbe082f92502d87e96ba9731d"
+    sha256 cellar: :any,                 high_sierra:    "ca2c1296318425931c5eec52c70adf98665edeb19d5b681271c3b6353ddf171a"
+    sha256 cellar: :any,                 sierra:         "3b1d75af49217a58f5ecb6f0e9e34564b299903898c76145218a6496de3a7778"
+    sha256 cellar: :any,                 el_capitan:     "941e267b5a214013c8085c7918c0d8c1805c906cacf162191b764d2ae1df265f"
+    sha256 cellar: :any,                 yosemite:       "cd8dd2f943081a051214bf0eedb3c1431abf2bb060a528058e6b9d4c841995ce"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c4b36bc47648e0f0c1f54755ba7320310a5bd321baa33aab440de475644a7c85"
   end
 
   depends_on "id3lib"

--- a/Formula/kubevela.rb
+++ b/Formula/kubevela.rb
@@ -8,12 +8,12 @@ class Kubevela < Formula
   head "https://github.com/kubevela/kubevela.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7e9d86c212cff4f384810934cbb0df53ef41e23cfb92c1e3ed38a7f977913f18"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7e9d86c212cff4f384810934cbb0df53ef41e23cfb92c1e3ed38a7f977913f18"
-    sha256 cellar: :any_skip_relocation, monterey:       "4f8870b53bf921f69988d74988c2a89cc9e70a109c0f533f0fd40f7221e2eead"
-    sha256 cellar: :any_skip_relocation, big_sur:        "4f8870b53bf921f69988d74988c2a89cc9e70a109c0f533f0fd40f7221e2eead"
-    sha256 cellar: :any_skip_relocation, catalina:       "4f8870b53bf921f69988d74988c2a89cc9e70a109c0f533f0fd40f7221e2eead"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2c2efda33babe6348f619cab8cfda097a3e4c3ff1b12eb819c036b58c9f9c680"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ff321dd00b5111be9e4fb9fdc70803c8e1684077c33ee7a59b78c6133e18ed4e"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ff321dd00b5111be9e4fb9fdc70803c8e1684077c33ee7a59b78c6133e18ed4e"
+    sha256 cellar: :any_skip_relocation, monterey:       "f815f5849b232dfe0538793172499274667b0cc23dfb5f063759dfc99bd35c27"
+    sha256 cellar: :any_skip_relocation, big_sur:        "f815f5849b232dfe0538793172499274667b0cc23dfb5f063759dfc99bd35c27"
+    sha256 cellar: :any_skip_relocation, catalina:       "f815f5849b232dfe0538793172499274667b0cc23dfb5f063759dfc99bd35c27"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17e68b0f3ffd4635906bda8cb6ffa57a6773357c1ddde254813f224e9c381771"
   end
 
   depends_on "go" => :build

--- a/Formula/kubevela.rb
+++ b/Formula/kubevela.rb
@@ -2,8 +2,8 @@ class Kubevela < Formula
   desc "Application Platform based on Kubernetes and Open Application Model"
   homepage "https://kubevela.io"
   url "https://github.com/kubevela/kubevela.git",
-      tag:      "v1.3.4",
-      revision: "d748096f7c9a35c60c491dadbe1b8ff84d89d753"
+      tag:      "v1.3.5",
+      revision: "cbed2b5cb3371b48357dbda3b5fc278a506c4d70"
   license "Apache-2.0"
   head "https://github.com/kubevela/kubevela.git", branch: "master"
 

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -12,12 +12,12 @@ class Ninja < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8efac5a9c8b7028f64f5a092eb029ff40887b9895fe4235e3fb8bade6a24cada"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c2dc001768f9e52e1f5dc30c97e8c18e3b9711075ea68890a74adb4b4a5f2551"
-    sha256 cellar: :any_skip_relocation, monterey:       "7a28d090cbec60072c3df5c35be0fa45761d18ce06567120951aa0ded80ff72d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "b3e0b14cffa2d227c0b4140c1a3742a2a4e7e3966a429e1d253b0e29acfb6293"
-    sha256 cellar: :any_skip_relocation, catalina:       "11c2a3cf1cd415a81ff7206f48b77dbe851b593bd163979dfdcb11266d24307a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f3837361ee7a7d2646a84db1aee70fff51f957c573e0c7a61b04a91f1ce1ae24"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "46cdad783a36c60dcce23b8a1857e54dd0e3935f30ec4586596bad81c1b1c347"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1b87214797b286ee46413e9099f686bba663ea838cb688f2a59e4fc48b9c2a7e"
+    sha256 cellar: :any_skip_relocation, monterey:       "61f5f9c72b75a42e1f44a47932e476a1602594a8fe8e27a3dd73d89f4c356e8f"
+    sha256 cellar: :any_skip_relocation, big_sur:        "99b7e8cf83eb6eda1e6c787eb970a67df2725a67e5c476c85172ed6c5701f32a"
+    sha256 cellar: :any_skip_relocation, catalina:       "cdd5ba34ff65ec225548bd872dd775bc29fb4ae3994a2a4629d367dfb02eff2a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "745d1eb8dea681f16692b2dcdcb9e464547bb5d9c84e78b177898405421bc82b"
   end
 
   # Ninja only needs Python for some non-core functionality.

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -1,10 +1,9 @@
 class Ninja < Formula
   desc "Small build system for use with gyp or CMake"
   homepage "https://ninja-build.org/"
-  url "https://github.com/ninja-build/ninja/archive/v1.10.2.tar.gz"
-  sha256 "ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed"
+  url "https://github.com/ninja-build/ninja/archive/v1.11.0.tar.gz"
+  sha256 "3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368db143e4c6"
   license "Apache-2.0"
-  revision 1
   head "https://github.com/ninja-build/ninja.git", branch: "master"
 
   livecheck do
@@ -37,6 +36,7 @@ class Ninja < Formula
   end
 
   test do
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_bin
     (testpath/"build.ninja").write <<~EOS
       cflags = -Wall
 

--- a/Formula/pcb.rb
+++ b/Formula/pcb.rb
@@ -12,10 +12,12 @@ class Pcb < Formula
   end
 
   bottle do
-    sha256 arm64_big_sur: "41a14f1d1a3439469248dd6b58535c082f084376a90ecf3ccca2513e70cd2028"
-    sha256 big_sur:       "f73590271ddcf104d25fecad90c916e4d535a5041280a1bbd661acdafc806b24"
-    sha256 catalina:      "a8937f1ce318a6472532eae067dc581ddef61518a5b56db83883cb2119c2bf32"
-    sha256 mojave:        "0607471efce526eb3fd06286f28fa664276ab8b4c3f407b14e18eb3c426cad59"
+    sha256 arm64_monterey: "71f5ca60f422ffc8d6555560f37167aae20a07c103c35fa3d100feafb9a9bc01"
+    sha256 arm64_big_sur:  "41a14f1d1a3439469248dd6b58535c082f084376a90ecf3ccca2513e70cd2028"
+    sha256 big_sur:        "f73590271ddcf104d25fecad90c916e4d535a5041280a1bbd661acdafc806b24"
+    sha256 catalina:       "a8937f1ce318a6472532eae067dc581ddef61518a5b56db83883cb2119c2bf32"
+    sha256 mojave:         "0607471efce526eb3fd06286f28fa664276ab8b4c3f407b14e18eb3c426cad59"
+    sha256 x86_64_linux:   "96a5bd2ef750cb1ae31604bb9f2e78daae83d9e20d7f432fa656601471465370"
   end
 
   head do

--- a/Formula/prestodb.rb
+++ b/Formula/prestodb.rb
@@ -3,8 +3,8 @@ class Prestodb < Formula
 
   desc "Distributed SQL query engine for big data"
   homepage "https://prestodb.io"
-  url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.273/presto-server-0.273.tar.gz"
-  sha256 "790b27205ff387a1d55e30b9ae1d608d47be7199775c02e0999e030075a01ec1"
+  url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.273.1/presto-server-0.273.1.tar.gz"
+  sha256 "3615f1e2ad21368a8ff9686d409d22632e1267aed1c28d7f7fb0167da16ce30f"
   license "Apache-2.0"
 
   # Upstream has said that we should check Maven for Presto version information
@@ -25,8 +25,8 @@ class Prestodb < Formula
   depends_on "python@3.10"
 
   resource "presto-cli" do
-    url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.273/presto-cli-0.273-executable.jar"
-    sha256 "7ed29f81cfb2c0b3089e04f6dd836e67d208893630f0a2e8c6e78c12f5d1aa2c"
+    url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.273.1/presto-cli-0.273.1-executable.jar"
+    sha256 "74383b2c69cf6a5f851cf2feac09a35f89bd9f28480c01abd928de8fd9a7348c"
   end
 
   def install

--- a/Formula/prestodb.rb
+++ b/Formula/prestodb.rb
@@ -16,7 +16,7 @@ class Prestodb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "8d9c2cf66ed0fae3f5f852f7a49f3e7b29d6e84e0f73ce7ff39bfbd04e4ed0e7"
+    sha256 cellar: :any_skip_relocation, all: "820d07bff1d71856f8324f80b7c72ce1c8aa67500e6e25012fab9e5433bef1b8"
   end
 
   # https://github.com/prestodb/presto/issues/17146

--- a/Formula/python-tk@3.9.rb
+++ b/Formula/python-tk@3.9.rb
@@ -1,8 +1,8 @@
 class PythonTkAT39 < Formula
   desc "Python interface to Tcl/Tk"
   homepage "https://www.python.org/"
-  url "https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tar.xz"
-  sha256 "2cd94b20670e4159c6d9ab57f91dbf255b97d8c1a1451d1c35f4ec1968adf971"
+  url "https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tar.xz"
+  sha256 "125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f"
   license "Python-2.0"
 
   livecheck do

--- a/Formula/python-tk@3.9.rb
+++ b/Formula/python-tk@3.9.rb
@@ -10,12 +10,12 @@ class PythonTkAT39 < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_monterey: "f2a521b5ec62ef1e7e1c511b273fb1dc986c806c09195a01aea886c230ea3319"
-    sha256 cellar: :any, arm64_big_sur:  "efa108beb40cb7c780e43fe187a07122eb861d585311e211f873db4b7a006638"
-    sha256 cellar: :any, monterey:       "2437b01a2b1e4e70bffd7464bf7a5f4bb234114251fd873c804e3bdcd951f182"
-    sha256 cellar: :any, big_sur:        "4c615a7866b9b48d9b44e7758dae8139fa15795bbad1488f75a5bfffd013d10b"
-    sha256 cellar: :any, catalina:       "c3b5a2085a4cfe74bef1cd9facf0a6c5611eba927be9ba3161f7e10648a00420"
-    sha256               x86_64_linux:   "f905431bf679bce1ead237d759461c2350b2cb01231e374d3d0d0d025741e10b"
+    sha256 cellar: :any, arm64_monterey: "c8db074cc234c9e741340bed4f4778acc53d95ec29e41fa44628b05fbbbada1c"
+    sha256 cellar: :any, arm64_big_sur:  "f3092fdad2f1b38cbe9bcb2e6e7006a97a87dae28093170d7118a97bddb62ec1"
+    sha256 cellar: :any, monterey:       "44e117a901b6ac21405548aaee24b0cc5b9ded59ca73ffa33a631525348c6611"
+    sha256 cellar: :any, big_sur:        "09b0363a026fe863ca904dbee095505aa55ba302ff8764c5c49938ff6c15467c"
+    sha256 cellar: :any, catalina:       "4f3561d8c98d1536b6854273db9b666d0101dc889c18a021460fc20c536b3568"
+    sha256               x86_64_linux:   "3901b096d0d66fcd4655544b38bdb446bd1b285ff839a118204af51454f7799b"
   end
 
   depends_on "python@3.9"

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -11,12 +11,12 @@ class PythonAT39 < Formula
   end
 
   bottle do
-    sha256 arm64_monterey: "9e10c3a99301ae12a54e600f1c6123e48d266eeec0c5fb58e81ede30e00c56ad"
-    sha256 arm64_big_sur:  "c5c4504c0ac484f40d3d77ac8f16fd434f7e9dc32a2431c794f77656c1be3033"
-    sha256 monterey:       "2b890287fd18bb7e5040bcbf73b520de9ab1222daa0866ae1dd1ce7e59a5f130"
-    sha256 big_sur:        "673240742dd2dc0294fece30e067be597a5739da030809ca322e3a767b9e3171"
-    sha256 catalina:       "0d850afa702e5c6362bbe90d566bd6f19ad25d5ef5ffd784b79064bcf95aff82"
-    sha256 x86_64_linux:   "dda5176af96a752b29fc21e78e67588b35b5f4ca04065f420c0e4c0d493891cd"
+    sha256 arm64_monterey: "7bf1e26018eee5c546ffe26d499923415b74ef2d050f8cd4a26eb64be5a8a8e3"
+    sha256 arm64_big_sur:  "98716cf6ae69298492bdf5410416e71a6366a8dfd3130ae0312e9b00ef631cf6"
+    sha256 monterey:       "cfdb8bc2637984aa7bacf65bc5300cf5ba8299d66df176530f0a357dec97a451"
+    sha256 big_sur:        "5ae97ab75c4aea82321815441191f45c76b8cef4dce460775189b181536cc2fb"
+    sha256 catalina:       "24131535d449851adeadb2c71a937cafd83044bc1b78dc88c10508e642310248"
+    sha256 x86_64_linux:   "b3aaa19779fc4dad324ae7b1ca84796d958faf4b81bf2ddf3f2c51d520f82d1b"
   end
 
   # setuptools remembers the build flags python is built with and uses them to

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -1,10 +1,9 @@
 class PythonAT39 < Formula
   desc "Interpreted, interactive, object-oriented programming language"
   homepage "https://www.python.org/"
-  url "https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tar.xz"
-  sha256 "2cd94b20670e4159c6d9ab57f91dbf255b97d8c1a1451d1c35f4ec1968adf971"
+  url "https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tar.xz"
+  sha256 "125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f"
   license "Python-2.0"
-  revision 1
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -61,13 +60,13 @@ class PythonAT39 < Formula
 
   # Always update to latest release
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/af/e8/894c71e914dfbe01276a42dfad40025cd96119f2eefc39c554b6e8b9df86/setuptools-60.10.0.tar.gz"
-    sha256 "6599055eeb23bfef457d5605d33a4d68804266e6cb430b0fb12417c5efeae36c"
+    url "https://files.pythonhosted.org/packages/87/db/d840e1b888bd82b0b826b8864d1674df52f6d9d909177e1d144ab38a8c50/setuptools-62.3.1.tar.gz"
+    sha256 "28c79c24d83c42a5e6d6cc711e5e9a6c1b89326229feaa5807fc277040658600"
   end
 
   resource "pip" do
-    url "https://files.pythonhosted.org/packages/33/c9/e2164122d365d8f823213a53970fa3005eb16218edcfc56ca24cb6deba2b/pip-22.0.4.tar.gz"
-    sha256 "b3a9de2c6ef801e9247d1527a4b16f92f2cc141cd1489f3fffaf6a9e96729764"
+    url "https://files.pythonhosted.org/packages/99/bb/696e256f4f445809f25efd4e4ce42ff99664dc089cafa1e097d5fec7fc33/pip-22.1.tar.gz"
+    sha256 "2debf847016cfe643fa1512e2d781d3ca9e5c878ba0652583842d50cc2bcc605"
   end
 
   resource "wheel" do


### PR DESCRIPTION
Latest `master` for Pulsar has a hard dependency on JDK17. JDK17 has been supported and is tested working on the current bottled version (2.10) as well, so this should be backwards compatible.

ARM Mac builds should now also be possible, though we'll see how brew CI does with them since I've had some difficulty getting it to build on my m1.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
